### PR TITLE
Points for git hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ at least make a stab at reading that. This file is in
 Player List 
 -----------
 1. Pim Otte (@pimotte, 1 point)
-2. Stefan Hugtenburg (@MrHug)
+2. Stefan Hugtenburg (@MrHug, 1 point)
 3. Arthur Bik (@arthurbik)
 4. Jesse Donkervliet (@jdonkervliet)
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ request dated after any votes resets those votes.
 If the rule-change is adopted, a player who can shall merge the pull-request
 in a timely fashion, which marks completion of the vote.
 
-**301** If a PR that outlines a rule-change (in accordance with other rules in
-this file) contains `y` commit hashes containing an English dictionary word of 
-at least four consecutive letters, the proposer will be awarded `y` additional 
-points upon adoption of the rule-change.
+**302** If a PR that outlines a rule-change contains `y` commit hashes containing an English dictionary word of at least
+four consecutive letters, the proposer will be awarded `y` additional points when the PR is merged.
+
+An English dictionary word is defined as a word found in the Oxford Dictionary available
+[here](http://www.oxforddictionaries.com/). The default search setting of Eng (UK) is to be used as a search criterium.
+

--- a/README.md
+++ b/README.md
@@ -185,4 +185,7 @@ request dated after any votes resets those votes.
 If the rule-change is adopted, a player who can shall merge the pull-request
 in a timely fashion, which marks completion of the vote.
 
-
+**301** If a PR that outlines a rule-change in accordance with other rules in
+this file contains a commit hash containing an English dictionary word of at least 4
+consecutive letters, the proposer will be awarded one additional point if the
+rule change is adopted.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ request dated after any votes resets those votes.
 If the rule-change is adopted, a player who can shall merge the pull-request
 in a timely fashion, which marks completion of the vote.
 
-**301** If a PR that outlines a rule-change in accordance with other rules in
-this file contains a commit hash containing an English dictionary word of at least 4
-consecutive letters, the proposer will be awarded one additional point if the
-rule change is adopted.
+**301** If a PR that outlines a rule-change (in accordance with other rules in
+this file) contains `y` commit hashes containing an English dictionary word of 
+at least four consecutive letters, the proposer will be awarded `y` additional 
+points upon adoption of the rule-change.

--- a/README.md
+++ b/README.md
@@ -191,3 +191,6 @@ four consecutive letters, the proposer will be awarded `y` additional points whe
 An English dictionary word is defined as a word found in the Oxford Dictionary available
 [here](http://www.oxforddictionaries.com/). The default search setting of Eng (UK) is to be used as a search criterium.
 
+Points are only awarded if the proposer includes the `y` points in his update of his score and mentions this explicitly
+in his PR.
+


### PR DESCRIPTION
This new rule will allow us to get more points for rule-changes, if the PR contains a git commit hash that contains an English dictionary word of length at least 4. As this is relatively rare and (at the very least) random, I figured it might be fun to add that :wink:
