### PR TITLE
Rule 323: Automaticvote

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ at least make a stab at reading that. This file is in
 Player List 
 -----------
 1. Pim Otte (@pimotte, 5 points)
-2. Stefan Hugtenburg (@MrHug, 7 points)
+2. Stefan Hugtenburg (@MrHug, 8 points)
 3. Arthur Bik (@arthurbik, 1 point)
 4. Jesse Donkervliet (@jdonkervliet, 1 point)
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ gains 1 point.
 
 **315** Each eligible voter always has exactly one vote.
 
+**323** It may be assumed that the proposer of a rule-change is always in favour of this rule-change and thus has
+cast an implicit vote in favour of the rule-change. 
+An explicit vote through the procedures outlined in the rules may replace this implicit vote in favour.
+If the implicit vote is not overwritten with an explicit vote, the implicit vote is always valid, no matter what other
+rules say about the validity of votes.
+
 **207** The winner is the first player to achieve 200 (positive) points.
 
 **209** If two or more mutable rules conflict with one another, or if two or

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ gains 1 point.
 
 **323** It may be assumed that the proposer of a rule-change is always in favour of this rule-change and thus has
 cast an implicit vote in favour of the rule-change. 
-An explicit vote through the procedures outlined in the rules may replace this implicit vote in favour.
+An explicit vote through the procedures outlined in the rules replaces this implicit vote in favour.
 If the implicit vote is not overwritten with an explicit vote, the validity of the implicit vote is held to the same
 requirements as any other vote. For the purpose of validity checking, it can be considered an unwritten comment placed
 after all comments on the PR before the merging comment of the PR.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ gains 1 point.
 **323** It may be assumed that the proposer of a rule-change is always in favour of this rule-change and thus has
 cast an implicit vote in favour of the rule-change. 
 An explicit vote through the procedures outlined in the rules may replace this implicit vote in favour.
-If the implicit vote is not overwritten with an explicit vote, the implicit vote is always valid, no matter what other
-rules say about the validity of votes.
+If the implicit vote is not overwritten with an explicit vote, the validity of the implicit vote is held to the same
+requirements as any other vote. For the purpose of validity checking, it can be considered an unwritten comment placed
+after all comments on the PR before the merging comment of the PR.
 
 **207** The winner is the first player to achieve 200 (positive) points.
 


### PR DESCRIPTION
Voting for your own proposals seems a bit redundant...
For the sake of "getting some voting started" explicit voting is still allowed, overruling the implicit vote.
