### PR TITLE
339: Drugs rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ No player can be put on Trial for an offense committed more than 7 days (148 hou
 
 **339** *Drugs Policy*
 
-The minimum possible penalty associated with a Guilty Verdict is always a 0 point reduction except when the defendant
-pleads for a certain minimum penalty.
-No other rule may impose a minimum point reduction associated with a Guilty Verdict on any type of violation punishable
-by Trial.
+The minimum possible penalty associated with a Guilty Verdict is always a 0 point (or any other type of resource)
+reduction except when the defendant pleads for a certain minimum penalty.
+No other rule may impose a minimum point (or any other type of resource) reduction associated with a Guilty Verdict on
+any type of violation punishable by Trial.

--- a/README.md
+++ b/README.md
@@ -475,5 +475,5 @@ That issue will be ignored if a simple majority votes in favour of doing so.
 **329** *Drugs Policy*
 
 The minimum possible penalty associated with a Guilty Verdict is always a 0 point reduction. 
-No other rule may impose a minimum point reduction associated with a Guilty Verdict on any type of violation punishble
+No other rule may impose a minimum point reduction associated with a Guilty Verdict on any type of violation punishable
 by Trial.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ at least make a stab at reading that. This file is in
 Player List 
 -----------
 1. Pim Otte (@pimotte, 13.2 points)
-2. Stefan Hugtenburg (@MrHug, 11.1 points)
+2. Stefan Hugtenburg (@MrHug, 12.2 points)
 3. Arthur Bik (@arthurbik, 2 point)
 4. Jesse Donkervliet (@jdonkervliet, 3 point)
 
@@ -471,3 +471,9 @@ be read as specifying that the pull request should be merged in a timely fashion
 or "Judgement" are closed. Any player may start a vote in a separate issue to ignore a particular issue labelled 
 "Trial" or "Judgement" for purposes of this rule. 
 That issue will be ignored if a simple majority votes in favour of doing so.
+
+**329** *Drugs Policy*
+
+The minimum possible penalty associated with a Guilty Verdict is always a 0 point reduction. 
+No other rule may impose a minimum point reduction associated with a Guilty Verdict on any type of violation punishble
+by Trial.


### PR DESCRIPTION
"Weed card, it's what I need. Hardly ever... Okay, always. But it's not an addiction, cause my doctor gave me a
prescription." (Garfunkel and Oates, Weed Card)

I claim my 0.1 point for this quote.

This way we are always allowed to demand "gedoog" a violation, as in we acknowledge the crime (Guilty), but do not
subtract points. Note that it does still require the defense to demand a 0 point penalty. It is just that the defendant
can never be forced to choose between: Not Guilty and a guaranteed penalty. Thus rules such as: A violation that
requires a gamestate reversal should require at least a one point verdict if the defendant is found Guilty" are
prohibited.
