### PR TITLE
Begin of player profiles.

### DIFF
--- a/players/arthurbik.md
+++ b/players/arthurbik.md
@@ -18,3 +18,8 @@ Current score: 2
 | Issue | Title | Verdict|
 | ----- |:-----|:------|
 
+## Profile
+
+| (von) Karma | Afternoon Naps | Heart Rate | Hamsters |
+| ----------- | -------------- | ---------- | -------- |
+|           0 |              0 |          0 |        0 |

--- a/players/jdonkervliet.md
+++ b/players/jdonkervliet.md
@@ -19,3 +19,9 @@ Current score: 3
 | Issue | Title | Verdict|
 | ----- |:-----|:------|
 | [#44] | The people vs @jdonkervliet 1 | Guilty (0 points penalty) |
+
+## Profile
+
+| (von) Karma | Afternoon Naps | Heart Rate | Hamsters |
+| ----------- | -------------- | ---------- | -------- |
+|           0 |              0 |          0 |        0 |

--- a/players/maninthegithub.md
+++ b/players/maninthegithub.md
@@ -16,3 +16,9 @@ Current score: 1
 | Issue | Title | Verdict|
 | ----- |:-----|:------|
 
+
+## Profile
+
+| (von) Karma | Afternoon Naps | Heart Rate | Hamsters |
+| ----------- | -------------- | ---------- | -------- |
+|           0 |              0 |          0 |        0 |

--- a/players/mrhug.md
+++ b/players/mrhug.md
@@ -32,3 +32,9 @@ Current score: 16.4
 | ----- |:-----|:------|
 | [#34](https://github.com/pimotte/nomic/issue/34) | The people vs @MrHug 1 | Not Guilty |
 
+
+## Profile
+
+| (von) Karma | Afternoon Naps | Heart Rate | Hamsters |
+| ----------- | -------------- | ---------- | -------- |
+|           0 |              0 |          0 |        0 |

--- a/players/pimotte.md
+++ b/players/pimotte.md
@@ -30,3 +30,9 @@ Current score: 15.3
 | Issue | Title | Verdict|
 | ----- |:----- |:------ |
 | [#59](https://github.com/pimotte/nomic/issue/64) | The people vs @pimotte 1 | Not Guilty | 
+
+## Profile
+
+| (von) Karma | Afternoon Naps | Heart Rate | Hamsters |
+| ----------- | -------------- | ---------- | -------- |
+|           0 |              0 |          0 |        0 |

--- a/players/profiles.md
+++ b/players/profiles.md
@@ -1,0 +1,31 @@
+
+# Profiles
+
+Profiles are meant to describe the play style of the player. Players can
+increase or decrease their stats by playing the game.
+
+Currently, there are no rules how to modify these stats, and they are
+effectively frozen. 
+
+The stats are bound to specific gameplay elements. The table below gives an
+overview of their relation.
+
+ 1. (von) Karma is a Phoenix Wright reference and should reflect perfection in
+ play. For instance, getting a proposal accepted without additions or
+ retractions could increase this statistic.
+ 1. Afternoon Naps should reflect activity. An implementation could be the
+ inactivity-streak: the number of consecutive days that a player has had no
+ visible activity on GitHub.
+ 1. Heart Rate should reflect the number of times you (don't) get what you want.
+ For instance, getting a proposal accepted lowers your heart rate, but being
+ found guilty increases your heart rate.
+ 1. Hamsters show your supportive role in the game. You could obtain more
+ hamsters by voting and making constructive comments on a proposal.
+
+|            | (von) Karma | Afternoon Naps | Heart Rate | Hamsters |
+| ---------- | ----------- | -------------- | ---------- | -------- |
+| Proposals  |           x |              x |          x |          |
+| Discussion |             |              x |            |        x |
+| Voting     |             |              x |            |        x |
+| Legal      |             |              x |          x |          |
+


### PR DESCRIPTION
I wanted to add a crafting element to our game, which this _is not_.
This is a spin-off of that idea, where we can collect resources through regular play.
# Profiles

Profiles are meant to describe the play style of the player. Players can
increase or decrease their stats by playing the game.

Currently, there are no rules how to modify these stats, and they are
effectively frozen. 

The stats are bound to specific gameplay elements. The table below gives an
overview of their relation.
1. (von) Karma is a Phoenix Wright reference and should reflect perfection in
   play. For instance, getting a proposal accepted without additions or
   retractions could increase this statistic.
2. Afternoon Naps should reflect activity. An implementation could be the
   inactivity-streak: the number of consecutive days that a player has had no
   visible activity on GitHub.
3. Heart Rate should reflect the number of times you (don't) get what you want.
   For instance, getting a proposal accepted lowers your heart rate, but being
   found guilty increases your heart rate.
4. Hamsters show your supportive role in the game. You could obtain more
   hamsters by voting and making constructive comments on a proposal.

|  | (von) Karma | Afternoon Naps | Heart Rate | Hamsters |
| --- | --- | --- | --- | --- |
| Proposals | x | x | x |  |
| Discussion |  | x |  | x |
| Voting |  | x |  | x |
| Legal |  | x | x |  |
