### PR TITLE
370: Jury Nullification

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,20 @@ deduction than the prosecutor's proposal and should be a reduction of at least 0
 	point reduction. The rounded average (rounded to one decimal place) of these votes will be the final verdict of the
 	jury.
 
+**370** *The voice of the jury*
+
+In contrast to what other rules may state about the rendering of a Verdict, the jury is also allowed to invoke what is
+called _Jury Nullification_.
+
+The jury nullifies the crime of the defendant, that is they may believe he committed the crime he is charged with, but
+they do not believe he should be punished for this. (Note that this is different from a Not Guilty verdict, which
+implies the jury believes the defendant did not perform the act. Similarly it is different from a Guilty verdict with no
+punishment, because it does brand the defendant as a violater of the rules. Nullification is a statement from the jury
+that indicates they consider the offense commited so insignificant it should not even be considered an offense.)
+
+Whereas all juries have this right, the prosecution, defendant and people not involved in the Trial are not allowed to
+remind the jury of this right during a Trial either online or offline.
+
 **357** *The Right to Appeal*
 
 After the Verdict has been rendered the defendant has the right to _Appeal_ if at least two players eligible for jury

--- a/players/mrhug.md
+++ b/players/mrhug.md
@@ -2,7 +2,7 @@
 
 GitHub handle: @MrHug
 
-Current score: 30.6
+Current score: 31.6
 
 ##Accepted Pull Requests:
 


### PR DESCRIPTION
Because I still have not forgiven @pimotte for [this](https://github.com/pimotte/nomic/issues/59#issuecomment-225819554) dirty use of the "Trust-Jesse-to-YOLO-defense" in my Trial against him and the issue of Jury Nullification was recently brought back to my mind, I decided to look into it some more.

As it turns out it is forbidden (in the real world that is) to remind the jury of their right for jury nullification during a Trial. Whereas that seems like a weird rule to me (I mean, I know about it now, does that mean I could never be a jury member? Of course I do not live in the US, but still...) Anyway, since @pimotte was so happy to introduce this notion for his own case, I think we should do this properly, hence this rule proposal.

As outlined in the rule it is quite different from the two things that seem similar at first, let me try to explain this again:
- Jury Nullification: The jury believes the defendant has committed the act that he is charged with, but does not believe this should be considered a violation.
- Guilty, no punishment: The jury believes the defendant has committed the act that he is charged with and that is should be considered a _violation_, but does not believe a punishment is required in this case (it could lead to losing "von Karma" points for instance, but no real punishment is required).
- Not Guilty: The jury believes the defendant _did not_ commit the act he is charged with.

Obviously the jury can find out that they have this right and at least all of you will now know this (I suppose), but in the US jury members can also find out on their own, they are just not allowed to be told. The same holds here.
