### PR TITLE
Transfer of 1 points from @MrHug to @pimotte

### DIFF
--- a/players/mrhug.md
+++ b/players/mrhug.md
@@ -2,7 +2,7 @@
 
 GitHub handle: @MrHug
 
-Current score: 31.6
+Current score: 30.6
 
 ##Accepted Pull Requests:
 

--- a/players/pimotte.md
+++ b/players/pimotte.md
@@ -2,7 +2,7 @@
 
 GitHub handle: @pimotte
 
-Current score: 24.0
+Current score: 25.0
 
 ##Accepted Pull Requests:
 


### PR DESCRIPTION
I introduce one extra condition on this Transfer, namely that in order for this Transfer to be valid the following must hold:
- @pimotte has transferred at least 1 point to @MrHug in a Transfer with a link to this Transfer.

Additionally I will just mention this comment here: https://github.com/pimotte/nomic/pull/106#issuecomment-238206750
