### PR TITLE
Non-rule change: Add profile for Pim Veldhuisen

### DIFF
--- a/players/pimveldhuisen.md
+++ b/players/pimveldhuisen.md
@@ -1,0 +1,20 @@
+# Player: Pim Veldhuisen
+
+GitHub handle: @pimveldhuisen
+
+Current score: 0
+
+##Accepted Pull Requests:
+
+|  PR | Title | Points Gained|
+| --- |:----- |:------------ |
+
+
+##Trials:
+
+| Issue | Title | Verdict|
+| ----- |:----- |:------ |
+
+
+## Profile
+My favorite number is 88575

--- a/players/pimveldhuisen.md
+++ b/players/pimveldhuisen.md
@@ -2,7 +2,7 @@
 
 GitHub handle: @pimveldhuisen
 
-Current score: 0
+Current score: 2
 
 ##Accepted Pull Requests:
 
@@ -17,4 +17,4 @@ Current score: 0
 
 
 ## Profile
-My favorite number is 88575
+My favorite number is 225


### PR DESCRIPTION
~~In this PR, updating my profile, one commit hash containing the English dictionary word six-letter accede 
is present, making the PR eligible for a point according to rule 369: Hash Brownie Points.~~

In other, possibly related news, my .git directory for this repo now contains over half a million files.

EDIT: The PR now contains one hash containing a six-letter word, and another hash containting a five-letter word.
