### PR TITLE
376: Determining who receives points on point-awardable conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ One turn consists of proposing one rule-change and having it voted on.
 All players begin with the number of points equal to the outcome of this formula:
 `max(0, min_i(#points of player i) - 2)`
 
-**352** *Scrambling for points*
+**376** *Scrambling for points*
 
 A **point-awardable condition** is a condition on a PR on master of pimotte/nomic
 that may be rewarded with a number of points. 
@@ -437,8 +437,8 @@ A rule implementing a point-awardable condition must at least specifiy:
 - The condition under which points may be awarded
 - How many points may be awarded
 
-The number of points for a point-awardable condition will be awarded upon merging
-of the PR that fulfills the condition, if the PR reflects this awarding of points.
+The number of points for a point-awardable condition will, upon merging,
+be awarded to the initiator of a PR which fulfills the condition, if the PR reflects this awarding of points.
 
 Players cannot obtain points using a point-awardable condition introduced in *that* PR.
 

--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ All players begin with the number of points equal to the outcome of this formula
 A **point-awardable condition** is a condition on a PR on master of pimotte/nomic
 that may be rewarded with a number of points. 
 
+PRs are only eligble for point-awardable conditions if they are to be voted on.
+
 A rule implementing a point-awardable condition must at least specifiy:
 
 - The condition under which points may be awarded

--- a/players/pimveldhuisen.md
+++ b/players/pimveldhuisen.md
@@ -2,7 +2,7 @@
 
 GitHub handle: @pimveldhuisen
 
-Current score: 2
+Current score: 3
 
 ##Accepted Pull Requests:
 


### PR DESCRIPTION
I seems to me the rules on awarding points currently do not specify who receives points. This is an oversight that should be fixed.
