### PR TITLE
383: Explicit precedence for warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The merging of the pull request marks completion of the vote.
 
 During a simple majority vote, a player may warn the other players that the vote is going to end.
 If this warning raises no objections and a reasonable time has passed, the player who warned may resolve
-the vote as if the players who cast a (conditional) vote are the only eligible voters. 
+the vote as if the players who cast a valid (conditional) vote are the only eligible voters. 
 A reasonable time in this context is at least 72 hours and is at least enough time for the warning
 to reach all other players and for all other players to react to the warning. 
 An objection can be raised by any player at any time, this includes the option to raise objections

--- a/README.md
+++ b/README.md
@@ -254,16 +254,18 @@ If the rule-change is adopted, a player who can shall merge the pull request
 in a timely fashion, unless another rule specifies to wait.
 The merging of the pull request marks completion of the vote.
 
-**367** *Warning, no dawdling*
+**383** *Warning, no dawdling*
 
 During a simple majority vote, a player may warn the other players that the vote is going to end.
-If this warning raises no objections and a reasonable time has passed, the vote ends and the rule
-is adopted when a majority of the votes that are cast are in favor of the rule-change. 
+If this warning raises no objections and a reasonable time has passed, the player who warned may resolve
+the vote as if the players who cast a (conditional) vote are the only eligible voters. 
 A reasonable time in this context is at least 72 hours and is at least enough time for the warning
 to reach all other players and for all other players to react to the warning. 
 An objection can be raised by any player at any time, this includes the option to raise objections
 to future warnings. Commits that invalidate votes, also invalidate warnings. 
 Warnings on a PR that has a dependency automatically implies a warning on that dependency.
+
+This rule takes precedence over the rule that specified the simple majority vote.
 
 
 **321** *Retraction Watch*

--- a/players/pimotte.md
+++ b/players/pimotte.md
@@ -2,7 +2,7 @@
 
 GitHub handle: @pimotte
 
-Current score: 27.2
+Current score: 28.2
 
 ##Accepted Pull Requests:
 


### PR DESCRIPTION
I think the original was a little fuzzy, and because it didn't claim explicit precendence over 203, I'm not sure what would have happened. 

I have also removed the explicit reference to rule-changes, so this now also applies to non-changes.